### PR TITLE
Keep silent unless xyz2sgf is run directly from Node.js

### DIFF
--- a/xyz2sgf.js
+++ b/xyz2sgf.js
@@ -182,7 +182,6 @@ function load(filename) {
         }
         return parse(contents, ext);
     } else {
-        console.log("Couldn't detect file type -- make sure it has an extension of .gib, .ngf, .ugf || .ugi");
         throw new UnknownFormat();
     }
 
@@ -784,6 +783,9 @@ function main() {
             const outfilename = baseName(filename) + ".sgf";
             saveFile(outfilename, root);
         } catch (e) {
+            if (e instanceof UnknownFormat) {
+                console.log("Couldn't detect file type -- make sure it has an extension of .gib, .ngf, .ugf || .ugi");
+            }
             console.log(`Conversion failed for ${filename}`);
             console.log(e);
         }


### PR DESCRIPTION
I would like to avoid the console output "Couldn't detect file type -- make sure it has an extension of .gib, .ngf, .ugf || .ugi" when I use xyz2sgf in my program.

Anyway, thanks for publishing such a convenient library. It helps me much.
